### PR TITLE
ci: ♻️dependabot uses conventional commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/slidev/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build"
+      include: "scope"
     groups:
       dependencies:
         patterns:
@@ -12,6 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "ci"
     groups:
       ci:
         patterns:


### PR DESCRIPTION
## Sourcery によるサマリー

Dependabot が自動生成する PR に、 Conventional Commit のプレフィックスを使用するように設定します。

CI:
- `/slidev/` ディレクトリ内の Dependabot による更新に、スコープを含めた 'build' プレフィックスを追加
- ルートディレクトリ内の Dependabot による更新に、'ci' プレフィックスを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Dependabot to use conventional commit prefixes for its automated update PRs

CI:
- Add 'build' prefix with scope inclusion for Dependabot updates in /slidev/ directory
- Add 'ci' prefix for Dependabot updates in the root directory

</details>