### PR TITLE
chore: add asset label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+🍱asset:
+- changed-files:
+  - any-glob-to-any-file: 'static/**'
 ♻️ci:
 - changed-files:
   - any-glob-to-any-file: '.github/**/*.yml'


### PR DESCRIPTION
## Sourceryによる要約

GitHubラベラー設定において、`static/**` ディレクトリ内の変更に対して `🍱asset` ラベルを追加

CI:
- アセットの変更を認識するように labeler.yml を更新

Chores:
- ラベラー設定にアセットラベルを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add `🍱asset` label for changes in the `static/**` directory in the GitHub labeler configuration

CI:
- Update labeler.yml to recognize asset changes

Chores:
- Add asset label to labeler config

</details>