### PR TITLE
ci: version up checkout action

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🐣 Install bun

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -18,7 +18,7 @@ jobs:
       commitlint_log: ${{ steps.commitlint.outputs.commitlint_log }}
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: 🐣 Install bun


### PR DESCRIPTION
## Sourceryによる要約

commitlintおよびPRタイトルlintのCIワークフローで、GitHub Actionsのcheckoutアクションをv5にアップグレードしました。

CI:
- commitlintワークフローでactions/checkoutをv4からv5に更新
- pull-request-title-lintワークフローでactions/checkoutをv4からv5に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the GitHub Actions checkout action to v5 in CI workflows for commitlint and PR title lint

CI:
- Bump actions/checkout from v4 to v5 in commitlint workflow
- Bump actions/checkout from v4 to v5 in pull-request-title-lint workflow

</details>