### PR TITLE
ci: disable persist-credentials on checkout actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
@@ -33,7 +34,6 @@ jobs:
           ignores: [(message: string) => message.includes("Signed-off-by: dependabot[bot]")] }' > commitlint.config.ts
 
       - name: 👀 Validate PR title with commitlint
-        if: github.event_name == 'pull_request'
         id: commitlint
         env:
           TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Sourceryによる概要

GitHub Actionsのチェックアウトにおける認証情報の永続化を無効にし、不要なイベント条件を削除することでcommitlintワークフローを合理化します。

CI:
- pull-request-title-lintおよびcommitlintワークフローのチェックアウトステップでpersist-credentialsを無効にする
- PRタイトルの検証ステップにおけるgithub.event_nameの条件チェックを削除する

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable credential persistence on GitHub Actions checkouts and streamline the commitlint workflow by removing an unnecessary event conditional

CI:
- Disable persist-credentials in checkout steps of pull-request-title-lint and commitlint workflows
- Remove the conditional check on github.event_name for the PR title validation step

</details>