### PR TITLE
ci: polish comment.yml

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -23,50 +23,41 @@ jobs:
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
-      - name: ⚙️ Setup Environment
-        run: |
-          echo "PR_NUMBER=$(cat pr_number/pr_number.txt | tr -cd '0-9')" >> $GITHUB_ENV
-          echo "TITLE=$(cat title/title.txt | tr -d '\n')" >> $GITHUB_ENV
-          UUID=$(uuidgen)
-          {
-            echo "COMMENT<<EOF_$UUID"
-            cat comment/comment.txt
-            echo "EOF_$UUID"
-          } >> "$GITHUB_ENV"
 
       - name: 💬 Add a comment
         uses: actions/github-script@v9
         env:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         with:
           script: |
+            const fs = require('fs');
+
+            const prNumber = fs.readFileSync('pr_number/pr_number.txt', 'utf8').replace(/[^0-9]/g, '');
+            const comment = fs.readFileSync('comment/comment.txt', 'utf8');
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
+              issue_number: prNumber,
             })
-            const oldComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(process.env.TITLE)
+            const oldComment = comments.find(c => {
+              return c.user.type === 'Bot' && c.body.includes(process.env.WORKFLOW_NAME)
             })
+            const shouldComment = oldComment || process.env.CONCLUSION === 'failure'
+            if (!shouldComment) return
+
             if (oldComment) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: oldComment.id,
               })
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: process.env.PR_NUMBER,
-                body: process.env.COMMENT
-              })
-              return
             }
-            if (process.env.CONCLUSION === 'failure') {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: process.env.PR_NUMBER,
-                body: process.env.COMMENT
-              })
-            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            })


### PR DESCRIPTION
## Summary by Sourcery

GitHub Script ステップ内で PR メタデータを直接読み込み、ワークフローのステータスと既存の bot コメントに基づいてコメント作成を制御することで、workflow コメント用ジョブを簡素化します。

CI:
- environment セットアップステップを削除し、PR 番号およびコメントの読み込み処理を GitHub Script アクション内に移動することで、コメント用 workflow を簡素化します。
- コメントを更新するロジックを変更し、workflow 名で過去の bot コメントを識別し、workflow が失敗した場合、または以前の bot コメントが存在する場合にのみコメントを投稿または更新するようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Streamline the workflow comment job to read PR metadata directly in the GitHub Script step and gate comment creation based on workflow status and existing bot comments.

CI:
- Simplify the comment workflow by removing the environment setup step and moving PR number and comment loading into the GitHub Script action.
- Change the logic for updating comments to identify prior bot comments by workflow name and only post or update comments when the workflow fails or a previous bot comment exists.

</details>